### PR TITLE
Update pybind11 git URL to the working one

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libs/pybind11"]
 	path = blockscipy/blocksci/pybind11
-	url = https://github.com/pybind/pybind11/
+	url = https://github.com/pybind/pybind11.git
 [submodule "libs/bitcoin-api-cpp"]
 	path = external/bitcoin-api-cpp
 	url = https://github.com/hkalodner/bitcoin-api-cpp.git


### PR DESCRIPTION
```
$ git clone https://github.com/pybind/pybind11/
Cloning into 'pybind11'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
````